### PR TITLE
MEL-70: Secure the admin interface

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -26,7 +26,7 @@ WORKDIR cantaloupe-${ctl_ver}
 RUN sed -e 's+home\/myself\/images+imageroot+' -e 's/#cache.server/cache.server/' < cantaloupe.properties.sample > ctlp.props \
   && mv cantaloupe-${ctl_ver}.war cantaloupe.war
 
-  RUN   sed -i "s/endpoint.admin.enabled = false/endpoint.admin.enabled = true/g" ctlp.props\
+RUN     sed -i "s/endpoint.admin.enabled = false/endpoint.admin.enabled = true/g" ctlp.props\
   &&    sed -i "s/endpoint.api.enabled = false/endpoint.api.enabled = true/g" ctlp.props\
   &&    sed -i "s/endpoint.admin.secret =/endpoint.admin.secret = admin/g" ctlp.props\
   &&    sed -i "s/endpoint.api.username =/endpoint.api.username = admin/g" ctlp.props\
@@ -44,7 +44,13 @@ RUN sed -e 's+home\/myself\/images+imageroot+' -e 's/#cache.server/cache.server/
   &&    sed -i "s/log.application.level = debug/log.application.level = all/g" ctlp.props\
   &&    sed -i "s/RollingFileAppender.enabled = false/RollingFileAppender.enabled = true/g" ctlp.props\
   &&    sed -i "\$a processor.selection_strategy = AutomaticSelectionStrategy" ctlp.props\
-  &&    sed -i "s/processor.tif =/processor.tif = JaiProcessor/g" ctlp.props
+  &&    sed -i "s/processor.tif =/processor.tif = JaiProcessor/g" ctlp.props\
+  &&    sed -i "s/endpoint.admin.enabled.*=.*/endpoint.admin.enabled = false/g" ctlp.props\
+  &&    sed -i "s/endpoint.admin.username.*=.*/endpoint.admin.username =/g" ctlp.props\
+  &&    sed -i "s/endpoint.admin.secret.*=.*/endpoint.admin.secret =/g" ctlp.props\
+  &&    sed -i "s/endpoint.api.enabled.*=.*/endpoint.api.enabled = false/g" ctlp.props\
+  &&    sed -i "s/endpoint.api.username.*=.*/endpoint.api.username =/g" ctlp.props\
+  &&    sed -i "s/endpoint.api.secret.*=.*/endpoint.api.secret =/g" ctlp.props
 
 EXPOSE 8182
 CMD source.sh

--- a/spec/image-server.postman_collection.json
+++ b/spec/image-server.postman_collection.json
@@ -12,8 +12,8 @@
 				"header": [],
 				"body": {},
 				"url": {
-					"raw": "https://{{image-server-host}}/",
-					"protocol": "https",
+					"raw": "{{image-server-protocol}}://{{image-server-host}}/",
+					"protocol": "{{image-server-protocol}}",
 					"host": [
 						"{{image-server-host}}"
 					],

--- a/spec/local_env.json
+++ b/spec/local_env.json
@@ -1,0 +1,13 @@
+{
+  "name": "image_server.test",
+  "values": [
+    {
+      "key": "image-server-host",
+      "value": "localhost:8182"
+    },
+    {
+      "key": "image-server-protocol",
+      "value": "http"
+    }
+  ]
+}


### PR DESCRIPTION
## MEL-70: Secure the admin interface

995d8b76434670b3cc33a11bc4909ca8d01a5430

Changed config to disable the admin and api interfaces. We currently have no need to hit these interfaces and don't want to add complexity to deployment where it's not needed.

Other changes:
- Created an example newman env that can be used locally
- Added variable for protocol to the tests so that they could be run locally without ssl
- Cleaned up the Readme a bit